### PR TITLE
fix: make shortcuts work in all machines correctly

### DIFF
--- a/src/features/game/components/game-view.tsx
+++ b/src/features/game/components/game-view.tsx
@@ -74,10 +74,12 @@ function GameView(props: IGameViewProps) {
           <div className="relative h-fit w-fit">
             <TypingArea onGameFinished={handleSnippetFinished} />
             <input
-              type="text"
-              autoFocus
+              className="peer absolute top-0 h-full w-full cursor-default rounded-2xl text-transparent caret-transparent backdrop-blur-xs transition-opacity duration-200 outline-none selection:bg-transparent focus:opacity-0 starting:opacity-0"
               ref={hiddenInputRef}
-              className="peer absolute top-0 h-full w-full cursor-default rounded-2xl text-transparent caret-transparent backdrop-blur-xs transition-opacity duration-200 outline-none selection:bg-transparent focus:opacity-0 [@starting-style]:opacity-0"
+              type="text"
+              value="PLACEHOLDER"
+              onChange={() => {}}
+              autoFocus
               autoComplete="off"
               autoCapitalize="off"
               autoCorrect="off"
@@ -87,7 +89,7 @@ function GameView(props: IGameViewProps) {
               list="autocompleteOff"
               spellCheck="false"
             />
-            <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-lg transition-opacity duration-200 peer-focus:opacity-0 [@starting-style]:opacity-0">
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-lg transition-opacity duration-200 peer-focus:opacity-0 starting:opacity-0">
               Click here or press any key to focus
             </div>
           </div>

--- a/src/features/game/logic/typing/keys.ts
+++ b/src/features/game/logic/typing/keys.ts
@@ -7,7 +7,7 @@ export function isAValidKey(event: KeyboardEvent) {
   return event.key.length === 1 || validExtraKeys.includes(event.key);
 }
 
-export function isAValidShortcutKey(event: KeyboardEvent) {
-  const validShortcutKeys = ["Backspace"];
-  return validShortcutKeys.includes(event.key);
+export function isAValidShortcutKey(event: InputEvent) {
+  const validShortcutKeys = ["deleteSoftLineBackward", "deleteWordBackward"];
+  return validShortcutKeys.includes(event.inputType);
 }


### PR DESCRIPTION
Shortcuts were inverted in non MacOS machines, this PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Enhanced text input handling to support additional input methods, including word and line deletion shortcuts.
* Improved keyboard event processing with refined modifier key detection for more reliable character input and deletion operations.

**Refactor**
* Restructured input event handling to consolidate keyboard and text input processing into a unified, maintainable flow for better stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->